### PR TITLE
director updated to pass the basepath and return internal infos

### DIFF
--- a/api/specs/director/v0/openapi.yaml
+++ b/api/specs/director/v0/openapi.yaml
@@ -319,6 +319,7 @@ components:
       schema:
         type: string
         example: '/x/EycCXbU0H/'
+        default: ''
 
     ServiceUuid:
       in: path

--- a/api/specs/shared/schemas/running_service.yaml
+++ b/api/specs/shared/schemas/running_service.yaml
@@ -64,4 +64,4 @@ components:
           description: different base path where current service is mounted otherwise defaults to root
           type: string
           example: '/x/E1O2E-LAH'
-          default: /
+          default: ''

--- a/packages/director-sdk/python/docs/InlineResponse201Data.md
+++ b/packages/director-sdk/python/docs/InlineResponse201Data.md
@@ -5,7 +5,10 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **entry_point** | **str** | The entry point where the service provides its interface if specified | [optional] 
 **published_port** | **int** | The ports where the service provides its interface | 
+**service_basepath** | **str** | different base path where current service is mounted otherwise defaults to root | [optional] 
+**service_host** | **str** | service host name within the network | 
 **service_key** | **str** | distinctive name for the node based on the docker registry path | 
+**service_port** | **int** | port to access the service within the network | 
 **service_uuid** | **str** | The UUID attached to this service | 
 **service_version** | **str** | semantic version number | 
 

--- a/packages/director-sdk/python/docs/UsersApi.md
+++ b/packages/director-sdk/python/docs/UsersApi.md
@@ -153,7 +153,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **running_interactive_services_post**
-> InlineResponse201 running_interactive_services_post(user_id, service_key, service_uuid, service_tag=service_tag)
+> InlineResponse201 running_interactive_services_post(user_id, service_key, service_uuid, service_tag=service_tag, service_basepath=service_basepath)
 
 Starts an interactive service in the oSparc platform and returns its entrypoint
 
@@ -173,10 +173,11 @@ user_id = asdfgj233 # str | The ID of the user that starts the service
 service_key = ["simcore/services/comp/itis/sleeper","simcore/services/dynamic/3dviewer"] # str | The key (url) of the service
 service_uuid = 123e4567-e89b-12d3-a456-426655440000 # str | The uuid to assign the service with
 service_tag = ["1.0.0","0.0.1"] # str | The tag/version of the service (optional)
+service_basepath = /x/EycCXbU0H/ # str | predefined basepath for the backend service otherwise uses root (optional)
 
 try:
     # Starts an interactive service in the oSparc platform and returns its entrypoint
-    api_response = api_instance.running_interactive_services_post(user_id, service_key, service_uuid, service_tag=service_tag)
+    api_response = api_instance.running_interactive_services_post(user_id, service_key, service_uuid, service_tag=service_tag, service_basepath=service_basepath)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling UsersApi->running_interactive_services_post: %s\n" % e)
@@ -190,6 +191,7 @@ Name | Type | Description  | Notes
  **service_key** | **str**| The key (url) of the service | 
  **service_uuid** | **str**| The uuid to assign the service with | 
  **service_tag** | **str**| The tag/version of the service | [optional] 
+ **service_basepath** | **str**| predefined basepath for the backend service otherwise uses root | [optional] 
 
 ### Return type
 

--- a/packages/director-sdk/python/simcore_director_sdk/api/users_api.py
+++ b/packages/director-sdk/python/simcore_director_sdk/api/users_api.py
@@ -327,6 +327,7 @@ class UsersApi(object):
         :param str service_key: The key (url) of the service (required)
         :param str service_uuid: The uuid to assign the service with (required)
         :param str service_tag: The tag/version of the service
+        :param str service_basepath: predefined basepath for the backend service otherwise uses root
         :return: InlineResponse201
                  If the method is called asynchronously,
                  returns the request thread.
@@ -352,6 +353,7 @@ class UsersApi(object):
         :param str service_key: The key (url) of the service (required)
         :param str service_uuid: The uuid to assign the service with (required)
         :param str service_tag: The tag/version of the service
+        :param str service_basepath: predefined basepath for the backend service otherwise uses root
         :return: InlineResponse201
                  If the method is called asynchronously,
                  returns the request thread.
@@ -359,7 +361,7 @@ class UsersApi(object):
 
         local_var_params = locals()
 
-        all_params = ['user_id', 'service_key', 'service_uuid', 'service_tag']  # noqa: E501
+        all_params = ['user_id', 'service_key', 'service_uuid', 'service_tag', 'service_basepath']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -403,6 +405,8 @@ class UsersApi(object):
             query_params.append(('service_tag', local_var_params['service_tag']))  # noqa: E501
         if 'service_uuid' in local_var_params:
             query_params.append(('service_uuid', local_var_params['service_uuid']))  # noqa: E501
+        if 'service_basepath' in local_var_params:
+            query_params.append(('service_basepath', local_var_params['service_basepath']))  # noqa: E501
 
         header_params = {}
 

--- a/packages/director-sdk/python/simcore_director_sdk/models/inline_response201_data.py
+++ b/packages/director-sdk/python/simcore_director_sdk/models/inline_response201_data.py
@@ -34,7 +34,10 @@ class InlineResponse201Data(object):
     openapi_types = {
         'entry_point': 'str',
         'published_port': 'int',
+        'service_basepath': 'str',
+        'service_host': 'str',
         'service_key': 'str',
+        'service_port': 'int',
         'service_uuid': 'str',
         'service_version': 'str'
     }
@@ -42,17 +45,23 @@ class InlineResponse201Data(object):
     attribute_map = {
         'entry_point': 'entry_point',
         'published_port': 'published_port',
+        'service_basepath': 'service_basepath',
+        'service_host': 'service_host',
         'service_key': 'service_key',
+        'service_port': 'service_port',
         'service_uuid': 'service_uuid',
         'service_version': 'service_version'
     }
 
-    def __init__(self, entry_point=None, published_port=None, service_key=None, service_uuid=None, service_version=None):  # noqa: E501
+    def __init__(self, entry_point=None, published_port=None, service_basepath=None, service_host=None, service_key=None, service_port=None, service_uuid=None, service_version=None):  # noqa: E501
         """InlineResponse201Data - a model defined in OpenAPI"""  # noqa: E501
 
         self._entry_point = None
         self._published_port = None
+        self._service_basepath = None
+        self._service_host = None
         self._service_key = None
+        self._service_port = None
         self._service_uuid = None
         self._service_version = None
         self.discriminator = None
@@ -60,7 +69,11 @@ class InlineResponse201Data(object):
         if entry_point is not None:
             self.entry_point = entry_point
         self.published_port = published_port
+        if service_basepath is not None:
+            self.service_basepath = service_basepath
+        self.service_host = service_host
         self.service_key = service_key
+        self.service_port = service_port
         self.service_uuid = service_uuid
         self.service_version = service_version
 
@@ -115,6 +128,54 @@ class InlineResponse201Data(object):
         self._published_port = published_port
 
     @property
+    def service_basepath(self):
+        """Gets the service_basepath of this InlineResponse201Data.  # noqa: E501
+
+        different base path where current service is mounted otherwise defaults to root  # noqa: E501
+
+        :return: The service_basepath of this InlineResponse201Data.  # noqa: E501
+        :rtype: str
+        """
+        return self._service_basepath
+
+    @service_basepath.setter
+    def service_basepath(self, service_basepath):
+        """Sets the service_basepath of this InlineResponse201Data.
+
+        different base path where current service is mounted otherwise defaults to root  # noqa: E501
+
+        :param service_basepath: The service_basepath of this InlineResponse201Data.  # noqa: E501
+        :type: str
+        """
+
+        self._service_basepath = service_basepath
+
+    @property
+    def service_host(self):
+        """Gets the service_host of this InlineResponse201Data.  # noqa: E501
+
+        service host name within the network  # noqa: E501
+
+        :return: The service_host of this InlineResponse201Data.  # noqa: E501
+        :rtype: str
+        """
+        return self._service_host
+
+    @service_host.setter
+    def service_host(self, service_host):
+        """Sets the service_host of this InlineResponse201Data.
+
+        service host name within the network  # noqa: E501
+
+        :param service_host: The service_host of this InlineResponse201Data.  # noqa: E501
+        :type: str
+        """
+        if service_host is None:
+            raise ValueError("Invalid value for `service_host`, must not be `None`")  # noqa: E501
+
+        self._service_host = service_host
+
+    @property
     def service_key(self):
         """Gets the service_key of this InlineResponse201Data.  # noqa: E501
 
@@ -140,6 +201,33 @@ class InlineResponse201Data(object):
             raise ValueError(r"Invalid value for `service_key`, must be a follow pattern or equal to `/^(simcore)\/(services)\/(comp|dynamic)(\/[^\\s\/]+)+$/`")  # noqa: E501
 
         self._service_key = service_key
+
+    @property
+    def service_port(self):
+        """Gets the service_port of this InlineResponse201Data.  # noqa: E501
+
+        port to access the service within the network  # noqa: E501
+
+        :return: The service_port of this InlineResponse201Data.  # noqa: E501
+        :rtype: int
+        """
+        return self._service_port
+
+    @service_port.setter
+    def service_port(self, service_port):
+        """Sets the service_port of this InlineResponse201Data.
+
+        port to access the service within the network  # noqa: E501
+
+        :param service_port: The service_port of this InlineResponse201Data.  # noqa: E501
+        :type: int
+        """
+        if service_port is None:
+            raise ValueError("Invalid value for `service_port`, must not be `None`")  # noqa: E501
+        if service_port is not None and service_port < 1:  # noqa: E501
+            raise ValueError("Invalid value for `service_port`, must be a value greater than or equal to `1`")  # noqa: E501
+
+        self._service_port = service_port
 
     @property
     def service_uuid(self):

--- a/services/director/src/simcore_service_director/oas3/v0/openapi.yaml
+++ b/services/director/src/simcore_service_director/oas3/v0/openapi.yaml
@@ -14,6 +14,7 @@ components:
       name: service_basepath
       required: false
       schema:
+        default: ''
         example: /x/EycCXbU0H/
         type: string
     ServiceKey:
@@ -221,6 +222,7 @@ paths:
         name: service_basepath
         required: false
         schema:
+          default: ''
           example: /x/EycCXbU0H/
           type: string
       responses:

--- a/services/director/src/simcore_service_director/oas3/v0/openapi.yaml
+++ b/services/director/src/simcore_service_director/oas3/v0/openapi.yaml
@@ -8,6 +8,14 @@ components:
       schema:
         example: 123e4567-e89b-12d3-a456-426655440000
         type: string
+    ServiceBasePath:
+      description: predefined basepath for the backend service otherwise uses root
+      in: query
+      name: service_basepath
+      required: false
+      schema:
+        example: /x/EycCXbU0H/
+        type: string
     ServiceKey:
       description: The key (url) of the service
       in: query
@@ -208,6 +216,13 @@ paths:
         schema:
           example: 123e4567-e89b-12d3-a456-426655440000
           type: string
+      - description: predefined basepath for the backend service otherwise uses root
+        in: query
+        name: service_basepath
+        required: false
+        schema:
+          example: /x/EycCXbU0H/
+          type: string
       responses:
         '201':
           content:
@@ -227,6 +242,16 @@ paths:
                         format: int32
                         minimum: 1
                         type: integer
+                      service_basepath:
+                        default: ''
+                        description: different base path where current service is
+                          mounted otherwise defaults to root
+                        example: /x/E1O2E-LAH
+                        type: string
+                      service_host:
+                        description: service host name within the network
+                        example: jupyter_E1O2E-LAH
+                        type: string
                       service_key:
                         description: distinctive name for the node based on the docker
                           registry path
@@ -235,6 +260,11 @@ paths:
                         - simcore/services/dynamic/3dviewer
                         pattern: ^(simcore)/(services)/(comp|dynamic)(/[^\s/]+)+$
                         type: string
+                      service_port:
+                        description: port to access the service within the network
+                        example: 8081
+                        minimum: 1
+                        type: integer
                       service_uuid:
                         description: The UUID attached to this service
                         example: 123e4567-e89b-12d3-a456-426655440000
@@ -251,6 +281,8 @@ paths:
                     - service_uuid
                     - service_key
                     - service_version
+                    - service_host
+                    - service_port
                     type: object
                   error:
                     default: null
@@ -597,6 +629,16 @@ paths:
                         format: int32
                         minimum: 1
                         type: integer
+                      service_basepath:
+                        default: ''
+                        description: different base path where current service is
+                          mounted otherwise defaults to root
+                        example: /x/E1O2E-LAH
+                        type: string
+                      service_host:
+                        description: service host name within the network
+                        example: jupyter_E1O2E-LAH
+                        type: string
                       service_key:
                         description: distinctive name for the node based on the docker
                           registry path
@@ -605,6 +647,11 @@ paths:
                         - simcore/services/dynamic/3dviewer
                         pattern: ^(simcore)/(services)/(comp|dynamic)(/[^\s/]+)+$
                         type: string
+                      service_port:
+                        description: port to access the service within the network
+                        example: 8081
+                        minimum: 1
+                        type: integer
                       service_uuid:
                         description: The UUID attached to this service
                         example: 123e4567-e89b-12d3-a456-426655440000
@@ -621,6 +668,8 @@ paths:
                     - service_uuid
                     - service_key
                     - service_version
+                    - service_host
+                    - service_port
                     type: object
                   error:
                     default: null

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -535,10 +535,11 @@ def __get_service_key_version_from_docker_service(service: docker.models.service
     service_attrs = service.attrs
     service_full_name = str(
         service_attrs["Spec"]["TaskTemplate"]["ContainerSpec"]["Image"])
-    if config.REGISTRY_URL not in service_full_name:
+    if not service_full_name.startswith(config.REGISTRY_URL):
         raise exceptions.DirectorException(
             msg="Invalid service {}".format(service_full_name))
-    service_full_name = service_full_name.lstrip(config.REGISTRY_URL + "/")
+
+    service_full_name = service_full_name[len(config.REGISTRY_URL):]
     return service_full_name.split(":")[0], service_full_name.split(":")[1]
 
 def _get_service_basepath_from_docker_service(service: docker.models.services.Service) -> str:

--- a/services/director/src/simcore_service_director/rest/generated_code/models/inline_response201_data.py
+++ b/services/director/src/simcore_service_director/rest/generated_code/models/inline_response201_data.py
@@ -15,15 +15,21 @@ class InlineResponse201Data(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, entry_point=None, published_port=None, service_key=None, service_uuid=None, service_version=None):  # noqa: E501
+    def __init__(self, entry_point=None, published_port=None, service_basepath=None, service_host=None, service_key=None, service_port=None, service_uuid=None, service_version=None):  # noqa: E501
         """InlineResponse201Data - a model defined in OpenAPI
 
         :param entry_point: The entry_point of this InlineResponse201Data.  # noqa: E501
         :type entry_point: str
         :param published_port: The published_port of this InlineResponse201Data.  # noqa: E501
         :type published_port: int
+        :param service_basepath: The service_basepath of this InlineResponse201Data.  # noqa: E501
+        :type service_basepath: str
+        :param service_host: The service_host of this InlineResponse201Data.  # noqa: E501
+        :type service_host: str
         :param service_key: The service_key of this InlineResponse201Data.  # noqa: E501
         :type service_key: str
+        :param service_port: The service_port of this InlineResponse201Data.  # noqa: E501
+        :type service_port: int
         :param service_uuid: The service_uuid of this InlineResponse201Data.  # noqa: E501
         :type service_uuid: str
         :param service_version: The service_version of this InlineResponse201Data.  # noqa: E501
@@ -32,7 +38,10 @@ class InlineResponse201Data(Model):
         self.openapi_types = {
             'entry_point': 'str',
             'published_port': 'int',
+            'service_basepath': 'str',
+            'service_host': 'str',
             'service_key': 'str',
+            'service_port': 'int',
             'service_uuid': 'str',
             'service_version': 'str'
         }
@@ -40,14 +49,20 @@ class InlineResponse201Data(Model):
         self.attribute_map = {
             'entry_point': 'entry_point',
             'published_port': 'published_port',
+            'service_basepath': 'service_basepath',
+            'service_host': 'service_host',
             'service_key': 'service_key',
+            'service_port': 'service_port',
             'service_uuid': 'service_uuid',
             'service_version': 'service_version'
         }
 
         self._entry_point = entry_point
         self._published_port = published_port
+        self._service_basepath = service_basepath
+        self._service_host = service_host
         self._service_key = service_key
+        self._service_port = service_port
         self._service_uuid = service_uuid
         self._service_version = service_version
 
@@ -113,6 +128,54 @@ class InlineResponse201Data(Model):
         self._published_port = published_port
 
     @property
+    def service_basepath(self):
+        """Gets the service_basepath of this InlineResponse201Data.
+
+        different base path where current service is mounted otherwise defaults to root  # noqa: E501
+
+        :return: The service_basepath of this InlineResponse201Data.
+        :rtype: str
+        """
+        return self._service_basepath
+
+    @service_basepath.setter
+    def service_basepath(self, service_basepath):
+        """Sets the service_basepath of this InlineResponse201Data.
+
+        different base path where current service is mounted otherwise defaults to root  # noqa: E501
+
+        :param service_basepath: The service_basepath of this InlineResponse201Data.
+        :type service_basepath: str
+        """
+
+        self._service_basepath = service_basepath
+
+    @property
+    def service_host(self):
+        """Gets the service_host of this InlineResponse201Data.
+
+        service host name within the network  # noqa: E501
+
+        :return: The service_host of this InlineResponse201Data.
+        :rtype: str
+        """
+        return self._service_host
+
+    @service_host.setter
+    def service_host(self, service_host):
+        """Sets the service_host of this InlineResponse201Data.
+
+        service host name within the network  # noqa: E501
+
+        :param service_host: The service_host of this InlineResponse201Data.
+        :type service_host: str
+        """
+        if service_host is None:
+            raise ValueError("Invalid value for `service_host`, must not be `None`")  # noqa: E501
+
+        self._service_host = service_host
+
+    @property
     def service_key(self):
         """Gets the service_key of this InlineResponse201Data.
 
@@ -138,6 +201,33 @@ class InlineResponse201Data(Model):
             raise ValueError("Invalid value for `service_key`, must be a follow pattern or equal to `/^(simcore)\/(services)\/(comp|dynamic)(\/[^\\s\/]+)+$/`")  # noqa: E501
 
         self._service_key = service_key
+
+    @property
+    def service_port(self):
+        """Gets the service_port of this InlineResponse201Data.
+
+        port to access the service within the network  # noqa: E501
+
+        :return: The service_port of this InlineResponse201Data.
+        :rtype: int
+        """
+        return self._service_port
+
+    @service_port.setter
+    def service_port(self, service_port):
+        """Sets the service_port of this InlineResponse201Data.
+
+        port to access the service within the network  # noqa: E501
+
+        :param service_port: The service_port of this InlineResponse201Data.
+        :type service_port: int
+        """
+        if service_port is None:
+            raise ValueError("Invalid value for `service_port`, must not be `None`")  # noqa: E501
+        if service_port is not None and service_port < 1:  # noqa: E501
+            raise ValueError("Invalid value for `service_port`, must be a value greater than or equal to `1`")  # noqa: E501
+
+        self._service_port = service_port
 
     @property
     def service_uuid(self):

--- a/services/director/src/simcore_service_director/rest/handlers.py
+++ b/services/director/src/simcore_service_director/rest/handlers.py
@@ -54,12 +54,12 @@ async def _list_services(list_service_fct):
     services = node_validator.validate_nodes(services)
     return services
 
-async def running_interactive_services_post(request, user_id, service_key, service_uuid, service_tag):  # pylint:disable=unused-argument
-    log.debug("Client does running_interactive_services_post request %s with user_id %s service_key %s, service_uuid %s and service_tag %s",
-                request, user_id, service_key, service_uuid, service_tag)
+async def running_interactive_services_post(request, user_id, service_key, service_uuid, service_tag, service_basepath):  # pylint:disable=unused-argument
+    log.debug("Client does running_interactive_services_post request %s with user_id %s service %s:%s, service_uuid %s, service_basepath %s",
+                request, user_id, service_key, service_tag, service_uuid, service_basepath)
 
     try:
-        service = await producer.start_service(user_id, service_key, service_tag, service_uuid)
+        service = await producer.start_service(user_id, service_key, service_tag, service_uuid, service_basepath)
         return web.json_response(data=dict(data=service), status=201)
     except exceptions.ServiceStartTimeoutError as err:
         raise web_exceptions.HTTPInternalServerError(reason=str(err))

--- a/services/director/tests/fixtures/fake_services.py
+++ b/services/director/tests/fixtures/fake_services.py
@@ -78,8 +78,9 @@ def _build_push_image(docker_dir, registry_url, service_type, name, tag, sleep_t
     service_description = _create_service_description(service_type, name, tag, schema_version)
     docker_labels = _create_docker_labels(service_description)
     additional_docker_labels = [{"name": "constraints", "type": "string", "value": ["node.role==manager"]}]
-    internal_port = random.randint(1, 100000)
+    internal_port = None    
     if service_type == "dynamic":
+        internal_port = random.randint(1, 100000)
         additional_docker_labels.append({"name": "ports", "type": "int", "value": internal_port})
     docker_labels["simcore.service.settings"] = json.dumps(additional_docker_labels)
 

--- a/services/director/tests/fixtures/fake_services.py
+++ b/services/director/tests/fixtures/fake_services.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+import random
 from pathlib import Path
 
 import docker
@@ -77,8 +78,9 @@ def _build_push_image(docker_dir, registry_url, service_type, name, tag, sleep_t
     service_description = _create_service_description(service_type, name, tag, schema_version)
     docker_labels = _create_docker_labels(service_description)
     additional_docker_labels = [{"name": "constraints", "type": "string", "value": ["node.role==manager"]}]
+    internal_port = random.randint(1, 100000)
     if service_type == "dynamic":
-        additional_docker_labels.append({"name": "ports", "type": "int", "value": 8888})
+        additional_docker_labels.append({"name": "ports", "type": "int", "value": internal_port})
     docker_labels["simcore.service.settings"] = json.dumps(additional_docker_labels)
 
     if dependent_image is not None:
@@ -97,7 +99,8 @@ def _build_push_image(docker_dir, registry_url, service_type, name, tag, sleep_t
     return {
         "service_description":service_description,
         "docker_labels":docker_labels,
-        "image_path":image_tag
+        "image_path":image_tag,
+        "internal_port":internal_port
         }
 
 def _clean_registry(registry_url, list_of_images, schema_version="v1"):

--- a/services/director/tests/test_handlers.py
+++ b/services/director/tests/test_handlers.py
@@ -152,19 +152,22 @@ async def _start_get_stop_services(push_services, user_id):
     fake_request = "fake request"
 
     with pytest.raises(web_exceptions.HTTPInternalServerError, message="Expecting internal server error"):
-        web_response = await rest.handlers.running_interactive_services_post(fake_request, None, None, None, None)
+        web_response = await rest.handlers.running_interactive_services_post(fake_request, None, None, None, None, None)
 
     with pytest.raises(web_exceptions.HTTPInternalServerError, message="Expecting internal server error"):
-        web_response = await rest.handlers.running_interactive_services_post(fake_request, "None", None, None, None)
+        web_response = await rest.handlers.running_interactive_services_post(fake_request, "None", None, None, None, None)
 
     with pytest.raises(web_exceptions.HTTPInternalServerError, message="Expecting internal server error"):
-        web_response = await rest.handlers.running_interactive_services_post(fake_request, "None", "None", None, None)
+        web_response = await rest.handlers.running_interactive_services_post(fake_request, "None", "None", None, None, None)
 
     with pytest.raises(web_exceptions.HTTPNotFound, message="Expecting not found error"):
-        web_response = await rest.handlers.running_interactive_services_post(fake_request, "None", "None", "None", None)
+        web_response = await rest.handlers.running_interactive_services_post(fake_request, "None", "None", "None", None, None)
 
     with pytest.raises(web_exceptions.HTTPNotFound, message="Expecting not found error"):
-        web_response = await rest.handlers.running_interactive_services_post(fake_request, "None", "None", "None", "ablah")
+        web_response = await rest.handlers.running_interactive_services_post(fake_request, "None", "None", "None", "ablah", None)
+    
+    with pytest.raises(web_exceptions.HTTPNotFound, message="Expecting not found error"):
+        web_response = await rest.handlers.running_interactive_services_post(fake_request, "None", "None", "None", "ablah", "None")
 
     with pytest.raises(web_exceptions.HTTPInternalServerError, message="Expecting internal server error"):
         web_response = await rest.handlers.running_interactive_services_get(fake_request, None)
@@ -184,9 +187,10 @@ async def _start_get_stop_services(push_services, user_id):
         service_key = service_description["key"]
         service_tag = service_description["version"]
         service_port = created_service["internal_port"]
+        service_basepath = ""
         service_uuid = str(uuid.uuid4())
         # start the service
-        web_response = await rest.handlers.running_interactive_services_post(fake_request, user_id, service_key, service_uuid, service_tag)
+        web_response = await rest.handlers.running_interactive_services_post(fake_request, user_id, service_key, service_uuid, service_tag, service_basepath)
         assert web_response.status == 201
         assert web_response.content_type == "application/json"
         running_service_enveloped = json.loads(web_response.text)

--- a/services/director/tests/test_handlers.py
+++ b/services/director/tests/test_handlers.py
@@ -190,12 +190,19 @@ async def _start_get_stop_services(push_services, user_id):
         assert web_response.content_type == "application/json"
         running_service_enveloped = json.loads(web_response.text)
         assert isinstance(running_service_enveloped["data"], dict)
-        assert all(k in running_service_enveloped["data"] for k in ["service_uuid", "service_key", "service_version", "published_port", "entry_point"])
+        assert all(k in running_service_enveloped["data"] for k in ["service_uuid", "service_key", "service_version", "published_port", "entry_point", "service_host", "service_port", "service_basepath"])
         assert running_service_enveloped["data"]["service_uuid"] == service_uuid
         assert running_service_enveloped["data"]["service_key"] == service_key
         assert running_service_enveloped["data"]["service_version"] == service_tag
+        # assert running_service_enveloped["data"]["service_host"] == service_description["host"]
+        # assert running_service_enveloped["data"]["service_port"] == service_description["port"]
+        # assert running_service_enveloped["data"]["service_basepath"] == service_description["basepath"]
         service_published_port = running_service_enveloped["data"]["published_port"]
         service_entry_point = running_service_enveloped["data"]["entry_point"]
+        service_host = running_service_enveloped["data"]["service_host"]
+        service_port = running_service_enveloped["data"]["service_port"]
+        service_basepath = running_service_enveloped["data"]["service_basepath"]
+        
 
         # get the service
         web_response = await rest.handlers.running_interactive_services_get(fake_request, service_uuid)
@@ -209,6 +216,9 @@ async def _start_get_stop_services(push_services, user_id):
         assert running_service_enveloped["data"]["service_version"] == service_tag
         assert running_service_enveloped["data"]["published_port"] == service_published_port
         assert running_service_enveloped["data"]["entry_point"] == service_entry_point
+        assert running_service_enveloped["data"]["service_host"] == service_host
+        assert running_service_enveloped["data"]["service_port"] == service_port
+        assert running_service_enveloped["data"]["service_basepath"] == service_basepath
 
         # stop the service
         web_response = await rest.handlers.running_interactive_services_delete(fake_request, service_uuid)

--- a/services/director/tests/test_handlers.py
+++ b/services/director/tests/test_handlers.py
@@ -183,6 +183,7 @@ async def _start_get_stop_services(push_services, user_id):
         service_description = created_service["service_description"]
         service_key = service_description["key"]
         service_tag = service_description["version"]
+        service_port = created_service["internal_port"]
         service_uuid = str(uuid.uuid4())
         # start the service
         web_response = await rest.handlers.running_interactive_services_post(fake_request, user_id, service_key, service_uuid, service_tag)
@@ -195,12 +196,11 @@ async def _start_get_stop_services(push_services, user_id):
         assert running_service_enveloped["data"]["service_key"] == service_key
         assert running_service_enveloped["data"]["service_version"] == service_tag
         # assert running_service_enveloped["data"]["service_host"] == service_description["host"]
-        # assert running_service_enveloped["data"]["service_port"] == service_description["port"]
+        assert running_service_enveloped["data"]["service_port"] == service_port
         # assert running_service_enveloped["data"]["service_basepath"] == service_description["basepath"]
         service_published_port = running_service_enveloped["data"]["published_port"]
         service_entry_point = running_service_enveloped["data"]["entry_point"]
-        service_host = running_service_enveloped["data"]["service_host"]
-        service_port = running_service_enveloped["data"]["service_port"]
+        service_host = running_service_enveloped["data"]["service_host"]        
         service_basepath = running_service_enveloped["data"]["service_basepath"]
         
 


### PR DESCRIPTION
<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

- [x] director passes the base path to started services in SIMCORE_NODE_BASEPATH
- [x] director returns service_host, service_port and service_basepath as defined in the specs


## Related issue number

<!--
 Use [waffle.io] keywords in title/descriptions to trigger bot actions:

   - close, closes, close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved #[issueNumber]
   - connect to, connects to, connected to, connect, connects, connected #[issueNumber]
-->
closes #372

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] **Runs in the swarm**
- [x] If you design a new module, add your user to .github/CODEOWNERS

[waffle.io]:https://waffle.io/marketing-assets/documents/waffleio_cheatsheet_v1.pdf?utm_source=blog&utm_medium=cheatsheet-ctabutton&utm_campaign=cheatsheet
