### PR TITLE
removed pinned dependencies

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/websocket_client.py
+++ b/packages/pytest-simcore/src/pytest_simcore/websocket_client.py
@@ -36,7 +36,7 @@ async def socketio_client(socketio_url: str, security_cookie: str):
     clients = []
 
     async def connect(client_session_id) -> socketio.AsyncClient:
-        sio = socketio.AsyncClient()
+        sio = socketio.AsyncClient(ssl_verify=False)    # enginio 3.10.0 introduced ssl verification
         url = str(URL(socketio_url).with_query({'client_session_id': client_session_id}))
 
         headers = {}

--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -23,7 +23,6 @@ expiringdict
 jinja_app_loader
 jsondiff
 passlib
-python-socketio==4.3.1  # FIXME: fails test test_anonymous_websocket_connection https://travis-ci.com/github/ITISFoundation/osparc-simcore/jobs/317121817#L1092
-# SEE https://github.com/ITISFoundation/osparc-simcore/issues/1445
+python-socketio
 semantic_version
 aiodebug

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -25,7 +25,7 @@ celery==4.4.2             # via -r _base.in
 cffi==1.14.0              # via cryptography
 change-case==0.5.2        # via -r _base.in
 chardet==3.0.4            # via aiohttp
-cryptography==2.9         # via -r _base.in, aiohttp-session
+cryptography==2.9.1       # via -r _base.in, aiohttp-session
 expiringdict==1.2.0       # via -r _base.in
 hiredis==1.0.1            # via aioredis
 idna-ssl==1.1.0           # via aiohttp
@@ -49,7 +49,7 @@ psycopg2-binary==2.8.5    # via -r ../../../../packages/service-library/requirem
 pycparser==2.20           # via cffi
 pyrsistent==0.16.0        # via jsonschema
 python-engineio==3.12.1   # via python-socketio
-python-socketio==4.3.1    # via -r _base.in
+python-socketio==4.5.1    # via -r _base.in
 pytz==2019.3              # via celery
 pyyaml==5.3.1             # via -r ../../../../packages/service-library/requirements/_base.in, aiohttp-swagger, openapi-spec-validator
 semantic-version==2.8.4   # via -r _base.in

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -30,7 +30,7 @@ chardet==3.0.4            # via -r _base.txt, aiohttp, requests
 codecov==2.0.22           # via -r _test.in
 coverage==5.1             # via -r _test.in, codecov, coveralls, pytest-cov
 coveralls==2.0.0          # via -r _test.in
-cryptography==2.9         # via -r _base.txt, aiohttp-session
+cryptography==2.9.1       # via -r _base.txt, aiohttp-session
 docker==4.2.0             # via -r _test.in
 docopt==0.6.2             # via coveralls
 expiringdict==1.2.0       # via -r _base.txt
@@ -76,7 +76,7 @@ pytest-sugar==0.9.2       # via -r _test.in
 pytest==5.3.5             # via -r _test.in, pytest-aiohttp, pytest-cov, pytest-instafail, pytest-mock, pytest-sugar
 python-dateutil==2.8.1    # via faker
 python-engineio==3.12.1   # via -r _base.txt, python-socketio
-python-socketio==4.3.1    # via -r _base.txt
+python-socketio==4.5.1    # via -r _base.txt
 pytz==2019.3              # via -r _base.txt, celery
 pyyaml==5.3.1             # via -r _base.txt, aiohttp-swagger, openapi-spec-validator
 redis==3.4.1              # via -r _test.in

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -242,7 +242,7 @@ async def socketio_client(socketio_url: str, security_cookie: str):
     clients = []
 
     async def connect(client_session_id) -> socketio.AsyncClient:
-        sio = socketio.AsyncClient()
+        sio = socketio.AsyncClient(ssl_verify=False)    # enginio 3.10.0 introduced ssl verification
         url = str(URL(socketio_url).with_query({'client_session_id': client_session_id}))
         headers = {}
         if security_cookie:


### PR DESCRIPTION

<!--  **WIP-** prefix in title if still work in progress -->

## What do these changes do?

- fixture socketio_client -> uses ssl_verify=False because engineio 3.10.0 introduced ssl verification, default was True (tests run without ssl) (patched in 2 files, introduced in 1 new one)
- test_websocket_multiple_connections -> a timeout of 0.1 seconds was introduces after each disconnection, after engineio migrated its websocket client to aiohttp, it takes longer to disconnect
- test_anonymous_websocket_connection -> in version 4.4.0 of python-socketio the disconnection error was replaced with an event handler.

<!-- Please give a short brief about these changes. -->


## Related issue number

Should fix the following issues
https://github.com/ITISFoundation/osparc-simcore/issues/1445
https://github.com/ITISFoundation/osparc-simcore/pull/1444

<!-- Please add #issues -->


## How to test

<!-- Please explain how this can be tested. Also state wether this PR needs a full rebuild, database changes, etc. -->


## Checklist

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
