### PR TITLE
fixed test for py38

### DIFF
--- a/services/web/server/tests/integration/test_exporter.py
+++ b/services/web/server/tests/integration/test_exporter.py
@@ -161,39 +161,6 @@ def get_exported_projects() -> List[Path]:
     return [x for x in exporter_dir.glob("*.osparc")]
 
 
-@pytest.fixture
-async def monkey_patch_asyncio_subporcess(mocker):
-    # TODO: The below bug is not allowing me to fully test,
-    # mocking and waiting for an update
-    # https://bugs.python.org/issue35621
-    # this issue was patched in 3.8, no need
-    if sys.version_info.major == 3 and sys.version_info.minor >= 8:
-        raise RuntimeError(
-            "Issue no longer present in this version of python, "
-            "please remote this mock on python >= 3.8"
-        )
-
-    import subprocess
-
-    async def create_subprocess_exec(*command, **extra_params):
-        class MockResponse:
-            def __init__(self, command, **kwargs):
-                self.proc = subprocess.Popen(command, **extra_params)
-
-            async def communicate(self):
-                return self.proc.communicate()
-
-            @property
-            def returncode(self):
-                return self.proc.returncode
-
-        mock_response = MockResponse(command, **extra_params)
-
-        return mock_response
-
-    mocker.patch("asyncio.create_subprocess_exec", side_effect=create_subprocess_exec)
-
-
 @pytest.fixture(scope="session")
 def push_services_to_registry(
     docker_registry: str, node_meta_schema: Dict
@@ -294,7 +261,6 @@ async def test_import_export_import(
     db_engine,
     redis_client,
     export_version,
-    monkey_patch_asyncio_subporcess,
     simcore_services,
     monkey_patch_aiohttp_request_url,
 ):


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

  WIP:
  bugfix:
  🏗️ maintenance:

  (⚠️ devops)  = changes in devops config required before deploying
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
fixes failing test

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #26 : node_ports should have retry policies when upload/download fails  (FIXED)
- ITISFoundation/osparc-issues#304: (Part 2) Prep2Go: creating features to support complex S4L scripts (IMPLEMENTED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [ ] Did you change any service's API? Then make sure to bundle document and upgrade version (``make openapi-specs``, ``git commit ...`` and then ``make version-*``)
- [ ] Unit tests for the changes exist
- [ ] Runs in the swarm
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
